### PR TITLE
encapsulates queue messaging behaviour in dedicated object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: queue
 Title: Simple Multi-Threaded Task Queuing
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: 
     person("Danielle", "Navarro", , "djnavarro@protonmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7648-6578"))

--- a/R/queue_messenger.R
+++ b/R/queue_messenger.R
@@ -63,14 +63,19 @@ QueueMessenger <- R6::R6Class(
     update_task_done = function(id) {
       task_id <- private$tasks$get_task(id)$get_task_id()
       runtime <- private$tasks$get_task(id)$get_task_runtime()
-      paste0("Task done: ", task_id, " (", round(as.numeric(runtime), 2), "s)")
+      paste("Done:", task_id, "in", private$display_time(runtime))
     },
 
     update_final = function(state, finished_in) {
-      cli::cli_alert_success(paste0(
-        "Queue complete: ", sum(state == "done"),
-        " tasks done", " (", round(as.numeric(finished_in), 2), "s)"
+      cli::cli_alert_success(paste(
+        "Queue complete:", sum(state == "done"),
+        "tasks done in", private$display_time(finished_in)
       ))
+    },
+
+    # elapsed is a difftime
+    display_time = function(elapsed) {
+      format(elapsed, digits = 3)
     }
   )
 )

--- a/R/queue_messenger.R
+++ b/R/queue_messenger.R
@@ -1,14 +1,37 @@
+# QueueMessenger is an R6 class that handles the public messaging
+# behaviour of a Queue. It's not exported but it's partly documented
+# here for the sake of my future sanity
+
+#' @noRd
 QueueMessenger <- R6::R6Class(
   classname = "QueueMessenger",
 
   public = list(
 
+    #' @description Intialise the QueueMessenger
+    #' @param tasks The `TaskList` object for the associated `Queue`
+    #' @param message_type A character string specifying the type of messages
+    #' to display: "none" means the `QueueMessenger` will do nothing and all
+    #' calls to the `post()` method will return immediately, "minimal" means
+    #' that a spinner will appear in the console and update the user with
+    #' counts of the number of waiting, running, and finished tasks, and
+    #' "verbose" means that (in addition to the spinner), every time a task
+    #' completes a message will be printed for that task.
     initialize = function(tasks, message_type) {
       private$tasks <- tasks
       private$message_type <- message_type
       private$start_spinner()
     },
 
+    #' @description This is the method used to generate messages
+    #' @param state State vector for the `TaskList`. This is technically not
+    #' needed because the `QueueMessenger` could look it up on its own, but in
+    #' context this is included as an argument because the only time `post()` is
+    #' called is in the private `schedule()` method in `Queue`, and at that point
+    #' the scheduler has literally just asked the `TaskList` to retrieve the state
+    #' @param finished_in A difftime. Used to indicate that the `Queue` is
+    #' finishing (triggering the display of the completion message), and as a
+    #' measure of the completion time.
     post = function(state, finished_in = NULL) {
 
       # silent queues never post
@@ -41,12 +64,16 @@ QueueMessenger <- R6::R6Class(
 
   private = list(
 
+    # storage
     tasks = NULL,
     spinner = NULL,
     message_type = NULL,
 
+    # keeps track of the tasks known to have been done
+    # at the time the last time the QueueMessenger posted
     done = numeric(0),
 
+    # initialises a spinner object
     start_spinner = function() {
       private$spinner <- cli::make_spinner(
         which = "dots2",
@@ -54,6 +81,7 @@ QueueMessenger <- R6::R6Class(
       )
     },
 
+    # prints a nice message to the spinner
     update_spinner = function(state) {
       msg <- paste(
         "{spin} Queue progress:",
@@ -67,10 +95,12 @@ QueueMessenger <- R6::R6Class(
       private$spinner$spin(msg)
     },
 
+    # stops the spinner
     stop_spinner = function() {
       private$spinner$finish()
     },
 
+    # prints completion messages for a set of tasks
     update_tasks = function(ids) {
       for(id in ids) {
         task_id <- private$tasks$get_task(id)$get_task_id()
@@ -86,6 +116,7 @@ QueueMessenger <- R6::R6Class(
 
     },
 
+    # prints completion messages for the queue
     update_final = function(state, finished_in) {
       msg <- paste(
         "Queue complete:",
@@ -96,7 +127,7 @@ QueueMessenger <- R6::R6Class(
       cli::cli_alert_success(msg)
     },
 
-    # elapsed is a difftime
+    # formats a difftime for display
     display_time = function(elapsed) {
       format(elapsed, digits = 3)
     }

--- a/R/queue_messenger.R
+++ b/R/queue_messenger.R
@@ -1,0 +1,78 @@
+QueueMessenger <- R6::R6Class(
+  classname = "QueueMessenger",
+
+  public = list(
+
+    initialize = function(tasks, message_type) {
+      private$tasks <- tasks
+      private$message_type <- message_type
+      private$spinner <- private$make_spinner()
+    },
+
+    post = function(state, finished_in = NULL) {
+      if(private$message_type == "none") return(invisible(state))
+      if(private$message_type == "verbose") {
+        done <- which(state == "done")
+        just_done <- setdiff(done, private$done_last_update)
+        if(length(just_done) > 0) {
+          private$done_last_update <- done
+          private$spinner$finish()
+          for(id in just_done) cli::cli_alert(private$update_task_done(id))
+          private$spinner <- private$make_spinner()
+        }
+      }
+      if(private$message_type %in% c("verbose", "minimal")) {
+        private$spinner$spin(private$update_overall(state))
+      }
+      if(!is.null(finished_in)) {
+        private$spinner$finish()
+        private$update_final(state, finished_in)
+      }
+      invisible(state)
+    }
+  ),
+
+  private = list(
+
+    tasks = NULL,
+    spinner = NULL,
+    message_type = NULL,
+
+    which_tasks_done = function() {
+      which(vapply(
+        private$tasks,
+        function(t) t$get_task_state() == "done",
+        logical(1)
+      ))
+    },
+
+    done_last_update = numeric(0),
+
+    make_spinner = function() {
+      cli::make_spinner(which = "dots2", template = "{spin} Queue")
+    },
+
+    update_overall = function(state) {
+      n_waiting <- sum(state == "waiting")
+      n_running <- sum(state == "running")
+      n_done <- sum(state == "done")
+      paste("{spin} Queue progress:", n_waiting, "waiting", "\u1405",
+            n_running, "running", "\u1405", n_done, "done")
+    },
+
+    update_task_done = function(id) {
+      task_id <- private$tasks$get_task(id)$get_task_id()
+      runtime <- private$tasks$get_task(id)$get_task_runtime()
+      paste0("Task done: ", task_id, " (", round(as.numeric(runtime), 2), "s)")
+    },
+
+    update_final = function(state, finished_in) {
+      cli::cli_alert_success(paste0(
+        "Queue complete: ", sum(state == "done"),
+        " tasks done", " (", round(as.numeric(finished_in), 2), "s)"
+      ))
+    }
+  )
+)
+
+

--- a/R/task_list.R
+++ b/R/task_list.R
@@ -9,7 +9,7 @@
 #' adding, removing, and getting `Task`s. It can also report on the status of the
 #' `Task`s contained within the list and retrieve results from those `Task`s. What
 #' it cannot do is manage interactions with `Worker`s or arrange for the `Task`s to
-#' be executed. That's the job of the `Queu`e.
+#' be executed. That's the job of the `Queue`.
 #' @export
 TaskList <- R6::R6Class(
   classname = "TaskList",
@@ -17,7 +17,6 @@ TaskList <- R6::R6Class(
   public = list(
     #' @description Create a new task list
     initialize = function() {
-      private$spinner <- private$make_spinner()
     },
 
     #' @description Return the number of tasks in the list
@@ -48,45 +47,15 @@ TaskList <- R6::R6Class(
       private$tasks[[x]]
     },
 
-    #' @description Return the status of all tasks in the `TaskList`. If
-    #' requested, this method will also display messages summarising the
-    #' current state of the tasks, and any tasks that have completed since
-    #' the last time a status was returned. This messaging system is called
-    #' by `Queue` objects as they work on a tasks
-    #' @param message Character specifying what type of message to display:
-    #' "none" (the default), "minimal", or "verbose"
-    #' @param finished_in A numeric value or a difftime specifying how long
-    #' the tasks have taken to complete. This argument is only used when
-    #' displaying messages, and it is used only to trigger the display of a
-    #' tidy "all tasks completed" style message. It is purely cosmetic and
-    #' does not affect the task status.
+    #' @description Return the status of all tasks in the `TaskList`.
     #' @return A character vector specifying the completion status for all
     #' listed tasks
-    get_state = function(message = "none", finished_in = NULL) {
-      state <- vapply(
+    get_state = function() {
+      vapply(
         private$tasks,
         function(t) t$get_task_state(),
         character(1)
       )
-      if(message == "none") return(invisible(state))
-      if(message == "verbose") {
-        done <- private$which_tasks_done()
-        just_done <- setdiff(done, private$done_last_update)
-        if(length(just_done) > 0) {
-          private$done_last_update <- done
-          private$spinner$finish()
-          for(id in just_done) cli::cli_alert(private$update_task_done(id))
-          private$spinner <- private$make_spinner()
-        }
-      }
-      if(message %in% c("verbose", "minimal")) {
-        private$spinner$spin(private$update_overall(state))
-      }
-      if(!is.null(finished_in)) {
-        private$spinner$finish()
-        private$update_final(state, finished_in)
-      }
-      invisible(state)
     },
 
     #' @description Return a list of tasks in a given state
@@ -141,53 +110,13 @@ TaskList <- R6::R6Class(
   ),
 
   private = list(
-
     tasks = list(),
-
-    # subsets the tasks list
     get_subset = function(x) {
       subset_list <- TaskList$new()
       for(task in private$tasks[x]) {
         subset_list$add_task(task)
       }
       subset_list
-    },
-
-    which_tasks_done = function() {
-      which(vapply(
-        private$tasks,
-        function(t) t$get_task_state() == "done",
-        logical(1)
-      ))
-    },
-
-    done_last_update = numeric(0),
-
-    make_spinner = function() {
-      cli::make_spinner(which = "dots2", template = "{spin} Queue")
-    },
-
-    spinner = NULL,
-
-    update_overall = function(state) {
-      n_waiting <- sum(state == "waiting")
-      n_running <- sum(state == "running")
-      n_done <- sum(state == "done")
-      paste("{spin} Queue progress:", n_waiting, "waiting", "\u1405",
-            n_running, "running", "\u1405", n_done, "done")
-    },
-
-    update_task_done = function(id) {
-      task_id <- private$tasks[[id]]$get_task_id()
-      runtime <- private$tasks[[id]]$get_task_runtime()
-      paste0("Task done: ", task_id, " (", round(as.numeric(runtime), 2), "s)")
-    },
-
-    update_final = function(state, finished_in) {
-      cli::cli_alert_success(paste0(
-        "Queue complete: ", sum(state == "done"),
-        " tasks done", " (", round(as.numeric(finished_in), 2), "s)"
-      ))
     }
   )
 )

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,3 +68,4 @@ The results of the function call are always stored in a list column called `resu
 ```{r example-results}
 unlist(out$result)
 ```
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,4 +68,3 @@ The results of the function call are always stored in a list column called `resu
 ```{r example-results}
 unlist(out$result)
 ```
-

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ We execute the tasks by calling the `run()` method:
 
 ``` r
 out <- queue$run(message = "verbose")
-#> → Task done: task_1 (0.22s)
-#> → Task done: task_2 (0.27s)
-#> → Task done: task_3 (0.38s)
-#> → Task done: task_4 (0.49s)
-#> → Task done: task_5 (0.55s)
-#> → Task done: task_6 (0.66s)
-#> → Task done: task_7 (0.77s)
-#> → Task done: task_8 (0.87s)
-#> → Task done: task_9 (0.97s)
-#> → Task done: task_10 (1.07s)
-#> ✔ Queue complete: 10 tasks done (2.03s)
+#> → Task done: task_1 in 0.193 secs
+#> → Task done: task_2 in 0.255 secs
+#> → Task done: task_3 in 0.369 secs
+#> → Task done: task_4 in 0.489 secs
+#> → Task done: task_5 in 0.579 secs
+#> → Task done: task_6 in 0.696 secs
+#> → Task done: task_7 in 0.756 secs
+#> → Task done: task_8 in 0.859 secs
+#> → Task done: task_9 in 0.96 secs
+#> → Task done: task_10 in 1.06 secs
+#> ✔ Queue complete: 10 tasks done in 2.04 secs
 ```
 
 The output is stored in a tibble that contains a fairly detailed
@@ -82,16 +82,16 @@ out
 #> # A tibble: 10 × 17
 #>    task_id worker_id state result runtime fun   args         created            
 #>    <chr>       <int> <chr> <list> <drtn>  <lis> <list>       <dttm>             
-#>  1 task_1     451838 done  <dbl>  0.2182… <fn>  <named list> 2022-12-22 10:14:45
-#>  2 task_2     451851 done  <dbl>  0.2747… <fn>  <named list> 2022-12-22 10:14:45
-#>  3 task_3     451863 done  <dbl>  0.3828… <fn>  <named list> 2022-12-22 10:14:45
-#>  4 task_4     451875 done  <dbl>  0.4947… <fn>  <named list> 2022-12-22 10:14:45
-#>  5 task_5     451838 done  <dbl>  0.5494… <fn>  <named list> 2022-12-22 10:14:45
-#>  6 task_6     451851 done  <dbl>  0.6581… <fn>  <named list> 2022-12-22 10:14:45
-#>  7 task_7     451863 done  <dbl>  0.7681… <fn>  <named list> 2022-12-22 10:14:45
-#>  8 task_8     451875 done  <dbl>  0.8690… <fn>  <named list> 2022-12-22 10:14:45
-#>  9 task_9     451838 done  <dbl>  0.9734… <fn>  <named list> 2022-12-22 10:14:45
-#> 10 task_10    451851 done  <dbl>  1.0735… <fn>  <named list> 2022-12-22 10:14:45
+#>  1 task_1     460280 done  <dbl>  0.1927… <fn>  <named list> 2022-12-22 10:45:28
+#>  2 task_2     460292 done  <dbl>  0.2552… <fn>  <named list> 2022-12-22 10:45:28
+#>  3 task_3     460304 done  <dbl>  0.3691… <fn>  <named list> 2022-12-22 10:45:28
+#>  4 task_4     460316 done  <dbl>  0.4885… <fn>  <named list> 2022-12-22 10:45:28
+#>  5 task_5     460280 done  <dbl>  0.5792… <fn>  <named list> 2022-12-22 10:45:28
+#>  6 task_6     460292 done  <dbl>  0.6962… <fn>  <named list> 2022-12-22 10:45:28
+#>  7 task_7     460304 done  <dbl>  0.7555… <fn>  <named list> 2022-12-22 10:45:28
+#>  8 task_8     460316 done  <dbl>  0.8593… <fn>  <named list> 2022-12-22 10:45:28
+#>  9 task_9     460280 done  <dbl>  0.9601… <fn>  <named list> 2022-12-22 10:45:28
+#> 10 task_10    460292 done  <dbl>  1.0560… <fn>  <named list> 2022-12-22 10:45:28
 #> # … with 9 more variables: queued <dttm>, assigned <dttm>, started <dttm>,
 #> #   finished <dttm>, code <int>, message <chr>, stdout <list>, stderr <list>,
 #> #   error <list>

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ We execute the tasks by calling the `run()` method:
 
 ``` r
 out <- queue$run(message = "verbose")
-#> → Task done: task_1 (0.17s)
-#> → Task done: task_2 (0.3s)
-#> → Task done: task_3 (0.36s)
-#> → Task done: task_4 (0.48s)
-#> → Task done: task_5 (0.53s)
-#> → Task done: task_6 (0.64s)
-#> → Task done: task_7 (0.76s)
-#> → Task done: task_8 (0.86s)
+#> → Task done: task_1 (0.22s)
+#> → Task done: task_2 (0.27s)
+#> → Task done: task_3 (0.38s)
+#> → Task done: task_4 (0.49s)
+#> → Task done: task_5 (0.55s)
+#> → Task done: task_6 (0.66s)
+#> → Task done: task_7 (0.77s)
+#> → Task done: task_8 (0.87s)
 #> → Task done: task_9 (0.97s)
 #> → Task done: task_10 (1.07s)
 #> ✔ Queue complete: 10 tasks done (2.03s)
@@ -82,16 +82,16 @@ out
 #> # A tibble: 10 × 17
 #>    task_id worker_id state result runtime fun   args         created            
 #>    <chr>       <int> <chr> <list> <drtn>  <lis> <list>       <dttm>             
-#>  1 task_1     335633 done  <dbl>  0.1723… <fn>  <named list> 2022-12-21 16:43:57
-#>  2 task_2     335645 done  <dbl>  0.2955… <fn>  <named list> 2022-12-21 16:43:57
-#>  3 task_3     335657 done  <dbl>  0.3587… <fn>  <named list> 2022-12-21 16:43:57
-#>  4 task_4     335669 done  <dbl>  0.4754… <fn>  <named list> 2022-12-21 16:43:57
-#>  5 task_5     335633 done  <dbl>  0.5304… <fn>  <named list> 2022-12-21 16:43:57
-#>  6 task_6     335645 done  <dbl>  0.6419… <fn>  <named list> 2022-12-21 16:43:57
-#>  7 task_7     335657 done  <dbl>  0.7579… <fn>  <named list> 2022-12-21 16:43:57
-#>  8 task_8     335669 done  <dbl>  0.8647… <fn>  <named list> 2022-12-21 16:43:57
-#>  9 task_9     335633 done  <dbl>  0.9653… <fn>  <named list> 2022-12-21 16:43:57
-#> 10 task_10    335645 done  <dbl>  1.0666… <fn>  <named list> 2022-12-21 16:43:57
+#>  1 task_1     451838 done  <dbl>  0.2182… <fn>  <named list> 2022-12-22 10:14:45
+#>  2 task_2     451851 done  <dbl>  0.2747… <fn>  <named list> 2022-12-22 10:14:45
+#>  3 task_3     451863 done  <dbl>  0.3828… <fn>  <named list> 2022-12-22 10:14:45
+#>  4 task_4     451875 done  <dbl>  0.4947… <fn>  <named list> 2022-12-22 10:14:45
+#>  5 task_5     451838 done  <dbl>  0.5494… <fn>  <named list> 2022-12-22 10:14:45
+#>  6 task_6     451851 done  <dbl>  0.6581… <fn>  <named list> 2022-12-22 10:14:45
+#>  7 task_7     451863 done  <dbl>  0.7681… <fn>  <named list> 2022-12-22 10:14:45
+#>  8 task_8     451875 done  <dbl>  0.8690… <fn>  <named list> 2022-12-22 10:14:45
+#>  9 task_9     451838 done  <dbl>  0.9734… <fn>  <named list> 2022-12-22 10:14:45
+#> 10 task_10    451851 done  <dbl>  1.0735… <fn>  <named list> 2022-12-22 10:14:45
 #> # … with 9 more variables: queued <dttm>, assigned <dttm>, started <dttm>,
 #> #   finished <dttm>, code <int>, message <chr>, stdout <list>, stderr <list>,
 #> #   error <list>

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ We execute the tasks by calling the `run()` method:
 
 ``` r
 out <- queue$run(message = "verbose")
-#> → Task done: task_1 in 0.193 secs
-#> → Task done: task_2 in 0.255 secs
-#> → Task done: task_3 in 0.369 secs
-#> → Task done: task_4 in 0.489 secs
-#> → Task done: task_5 in 0.579 secs
-#> → Task done: task_6 in 0.696 secs
-#> → Task done: task_7 in 0.756 secs
-#> → Task done: task_8 in 0.859 secs
-#> → Task done: task_9 in 0.96 secs
-#> → Task done: task_10 in 1.06 secs
-#> ✔ Queue complete: 10 tasks done in 2.04 secs
+#> → Done: task_1 finished in 0.156 secs
+#> → Done: task_2 finished in 0.219 secs
+#> → Done: task_3 finished in 0.338 secs
+#> → Done: task_4 finished in 0.454 secs
+#> → Done: task_5 finished in 0.576 secs
+#> → Done: task_6 finished in 0.63 secs
+#> → Done: task_7 finished in 0.738 secs
+#> → Done: task_8 finished in 0.841 secs
+#> → Done: task_9 finished in 0.94 secs
+#> → Done: task_10 finished in 1.04 secs
+#> ✔ Queue complete: 10 tasks done in 1.91 secs
 ```
 
 The output is stored in a tibble that contains a fairly detailed
@@ -82,16 +82,16 @@ out
 #> # A tibble: 10 × 17
 #>    task_id worker_id state result runtime fun   args         created            
 #>    <chr>       <int> <chr> <list> <drtn>  <lis> <list>       <dttm>             
-#>  1 task_1     460280 done  <dbl>  0.1927… <fn>  <named list> 2022-12-22 10:45:28
-#>  2 task_2     460292 done  <dbl>  0.2552… <fn>  <named list> 2022-12-22 10:45:28
-#>  3 task_3     460304 done  <dbl>  0.3691… <fn>  <named list> 2022-12-22 10:45:28
-#>  4 task_4     460316 done  <dbl>  0.4885… <fn>  <named list> 2022-12-22 10:45:28
-#>  5 task_5     460280 done  <dbl>  0.5792… <fn>  <named list> 2022-12-22 10:45:28
-#>  6 task_6     460292 done  <dbl>  0.6962… <fn>  <named list> 2022-12-22 10:45:28
-#>  7 task_7     460304 done  <dbl>  0.7555… <fn>  <named list> 2022-12-22 10:45:28
-#>  8 task_8     460316 done  <dbl>  0.8593… <fn>  <named list> 2022-12-22 10:45:28
-#>  9 task_9     460280 done  <dbl>  0.9601… <fn>  <named list> 2022-12-22 10:45:28
-#> 10 task_10    460292 done  <dbl>  1.0560… <fn>  <named list> 2022-12-22 10:45:28
+#>  1 task_1     477826 done  <dbl>  0.1560… <fn>  <named list> 2022-12-22 11:38:06
+#>  2 task_2     477838 done  <dbl>  0.2185… <fn>  <named list> 2022-12-22 11:38:06
+#>  3 task_3     477850 done  <dbl>  0.3377… <fn>  <named list> 2022-12-22 11:38:06
+#>  4 task_4     477862 done  <dbl>  0.4538… <fn>  <named list> 2022-12-22 11:38:06
+#>  5 task_5     477826 done  <dbl>  0.5761… <fn>  <named list> 2022-12-22 11:38:06
+#>  6 task_6     477838 done  <dbl>  0.6299… <fn>  <named list> 2022-12-22 11:38:06
+#>  7 task_7     477850 done  <dbl>  0.7383… <fn>  <named list> 2022-12-22 11:38:06
+#>  8 task_8     477862 done  <dbl>  0.8409… <fn>  <named list> 2022-12-22 11:38:06
+#>  9 task_9     477826 done  <dbl>  0.9396… <fn>  <named list> 2022-12-22 11:38:06
+#> 10 task_10    477838 done  <dbl>  1.0424… <fn>  <named list> 2022-12-22 11:38:06
 #> # … with 9 more variables: queued <dttm>, assigned <dttm>, started <dttm>,
 #> #   finished <dttm>, code <int>, message <chr>, stdout <list>, stderr <list>,
 #> #   error <list>

--- a/man/TaskList.Rd
+++ b/man/TaskList.Rd
@@ -12,7 +12,7 @@ holds a collection of \code{Task} objects, along with a collection of methods fo
 adding, removing, and getting \code{Task}s. It can also report on the status of the
 \code{Task}s contained within the list and retrieve results from those \code{Task}s. What
 it cannot do is manage interactions with \code{Worker}s or arrange for the \code{Task}s to
-be executed. That's the job of the \code{Queu}e.
+be executed. That's the job of the \code{Queue}.
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -112,29 +112,11 @@ A \code{Task} object
 \if{html}{\out{<a id="method-TaskList-get_state"></a>}}
 \if{latex}{\out{\hypertarget{method-TaskList-get_state}{}}}
 \subsection{Method \code{get_state()}}{
-Return the status of all tasks in the \code{TaskList}. If
-requested, this method will also display messages summarising the
-current state of the tasks, and any tasks that have completed since
-the last time a status was returned. This messaging system is called
-by \code{Queue} objects as they work on a tasks
+Return the status of all tasks in the \code{TaskList}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TaskList$get_state(message = "none", finished_in = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TaskList$get_state()}\if{html}{\out{</div>}}
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{message}}{Character specifying what type of message to display:
-"none" (the default), "minimal", or "verbose"}
-
-\item{\code{finished_in}}{A numeric value or a difftime specifying how long
-the tasks have taken to complete. This argument is only used when
-displaying messages, and it is used only to trigger the display of a
-tidy "all tasks completed" style message. It is purely cosmetic and
-does not affect the task status.}
-}
-\if{html}{\out{</div>}}
-}
 \subsection{Returns}{
 A character vector specifying the completion status for all
 listed tasks

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -32,7 +32,7 @@ test_that("Queue can execute tasks", {
   Sys.sleep(.2)
 
   tasks <- queue$get_tasks()
-  state <- tasks$get_state(message = "none")
+  state <- tasks$get_state()
   expect_equal(state, c("done", "done", "done"))
 
   # check the auto-shutdown

--- a/tests/testthat/test-queue.R
+++ b/tests/testthat/test-queue.R
@@ -86,8 +86,9 @@ test_that("Verbose output produces spinner and task reports", {
   msg <- capture.output(out <- queue$run(message = "verbose"), type = "message")
 
   # printed something to message corresponding to expected message events
+  # (this is not an ideal way to test this)
   expect_true(length(grep("{spin}", msg, fixed = TRUE)) > 0) # spinner
-  expect_true(length(grep("Task done:", msg, fixed = TRUE)) > 0) # cli_alert prefix
+  expect_true(length(grep("Done:", msg, fixed = TRUE)) > 0) # cli_alert prefix
   expect_true(length(grep("Queue complete", msg, fixed = TRUE)) > 0) # final
 
 })


### PR DESCRIPTION
This PR moves the queue messaging behaviour to a dedicated R6 `QueueMessenger` object. In doing so it helps clean up the code by not cluttering up either the `Queue` or `TaskList` objects with reporter functions that aren't part of their core behaviour